### PR TITLE
Fixed several issues with includeWhere and thenIncludeWhere.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/node_modules/**
+**/*.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm-linq-repository",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Wraps TypeORM repository pattern and QueryBuilder using fluent, LINQ-style queries.",
   "main": "index.ts",
   "scripts": {

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -277,7 +277,8 @@ export class Query<T extends { id: number }, R = T | T[], P = T> implements IQue
 
     private createIncludeWhere(includeProperty: string, includeConditionProperty: string): void {
         let joinProperty: string = `${this._lastAlias}.${includeProperty}`;
-        let joinAlias: string = includeProperty;
+        let joinAlias: string = `${this._lastAlias}_${includeProperty}`;
+        this._lastAlias = joinAlias;
         let joinCondition: string = `${joinAlias}.${includeConditionProperty}`;
         this._queryParts.push(new QueryBuilderPart(
             this._query.leftJoinAndSelect, [joinProperty, joinAlias, joinCondition]

--- a/src/query/interfaces/IQuery.ts
+++ b/src/query/interfaces/IQuery.ts
@@ -23,7 +23,7 @@ export interface IQuery<T extends { id: number }, R = T | T[], P = T> {
      * @param propertySelector Property selection lambda for property to include, ex. x => x.prop
      * @param subPropertySelector Property selection lambda for the subproperty on the included entity on which to filter.
      */
-    includeWhere<S extends Object>(propertySelector: (obj: T) => S[], subPropertySelector: (obj: S) => any): IComparableQuery<T, R, S>;
+    includeWhere<S extends Object>(propertySelector: (obj: T) => S | S[], subPropertySelector: (obj: S) => any): IComparableQuery<T, R, S>;
     /**
      * Adds an additional logical OR condition for which to query results.
      * @param propertySelector Property selection lambda for property to compare.
@@ -80,7 +80,7 @@ export interface IQuery<T extends { id: number }, R = T | T[], P = T> {
      * @param propertySelector Property selection lambda for property to include, ex. x => x.prop
      * @param subPropertySelector Property selection lambda for the subproperty on the included entity on which to filter.
      */
-    thenIncludeWhere<S extends Object>(propertySelector: (obj: P) => S[], subPropertySelector: (obj: S) => any): IComparableQuery<T, R, S>;
+    thenIncludeWhere<S extends Object>(propertySelector: (obj: P) => S | S[], subPropertySelector: (obj: S) => any): IComparableQuery<T, R, S>;
     /**
      * Invokes and returns the Promise to get the underlying QueryBuilder's results.
      */


### PR DESCRIPTION
Fixed: compile-time error when selecting non-array property in includeWhere and thenIncludeWhere; inability to select relations of relations which share the same name; inability to continue including relations after an includeWhere or thenIncludeWhere.