### PR TITLE
Use linq repo without defining a class

### DIFF
--- a/src/repository/get-default-repo.ts
+++ b/src/repository/get-default-repo.ts
@@ -1,0 +1,9 @@
+import { RepositoryBase, RepositoryOptions } from 'typeorm-linq-repository';
+
+export function getDefaultRepo<T>(modelClass: { new (): T }, opts?: RepositoryOptions) {
+  return new class extends RepositoryBase<T> {
+    public constructor() {
+      super(modelClass, opts);
+    }
+  }();
+}


### PR DESCRIPTION
This function can now be used like this without having to manually type the class
```
import { getDefaultRepo } from 'typeorm-linq-repository';

const userRepo = getDefaultRepo(UserModel);

const allUsers = await getDefaultRepo().getAll()
      .include(user => user.mdl_user_enrolments)
      .thenInclude(mdl_user_enrolments => mdl_user_enrolments.enrol)
      .thenInclude(enrol => enrol.course);
```