### PR TITLE
added ordering by nulls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm-linq-repository",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-alpha.20",
   "description": "Wraps TypeORM repository pattern and QueryBuilder using fluent, LINQ-style queries.",
   "main": "index.js",
   "scripts": {

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -490,7 +490,7 @@ export class Query<T extends EntityBase, R extends T | T[], P = T>
         }
     }
 
-    private completeOrderBy(queryAction: (...params: any[]) => any, queryParams: any[], options?: QueryOrderOptions): IQuery<T, R, P>{
+    private completeOrderBy(queryAction: (...params: any[]) => SelectQueryBuilder<T>, queryParams: any[], options?: QueryOrderOptions): IQuery<T, R, P>{
         if (options) {
             if (typeof (options.nullsFirst) === "boolean") {
                     queryParams.push(options.nullsFirst ? "NULLS FIRST" : "NULLS LAST");

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -493,7 +493,7 @@ export class Query<T extends EntityBase, R extends T | T[], P = T>
     private completeOrderBy(queryAction: (...params: any[]) => any, queryParams: any[], options?: QueryOrderOptions): IQuery<T, R, P>{
         if (options) {
             if (typeof (options.nullsFirst) === "boolean") {
-                    queryParams.push(options.nullsFirst ? "NULLS FIRST":"NULLS LAST");
+                    queryParams.push(options.nullsFirst ? "NULLS FIRST" : "NULLS LAST");
             }
         }
         this._queryParts.push(new QueryBuilderPart(

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -16,6 +16,7 @@ import { IQueryInternal } from "./interfaces/IQueryInternal";
 import { ISelectQuery } from "./interfaces/ISelectQuery";
 import { ISelectQueryInternal } from "./interfaces/ISelectQueryInternal";
 import { QueryBuilderPart } from "./QueryBuilderPart";
+import { QueryOrderOptions } from "../types/QueryOrderOptions";
 
 export class Query<T extends EntityBase, R extends T | T[], P = T>
     implements IQuery<T, R, P>, IJoinedQuery<T, R, P>,
@@ -257,26 +258,26 @@ export class Query<T extends EntityBase, R extends T | T[], P = T>
         return this.andOr(propertySelector, SqlConstants.OPERATOR_OR, this._query.orWhere);
     }
 
-    public orderBy(propertySelector: (obj: P) => any): IQuery<T, R, P> {
+    public orderBy(propertySelector: (obj: P) => any, options?: QueryOrderOptions): IQuery<T, R, P> {
         const propertyName: string = nameof<P>(propertySelector);
         const orderProperty: string = `${this._lastAlias}.${propertyName}`;
-        this._queryParts.push(new QueryBuilderPart(
-            this._query.orderBy,
-            [orderProperty, "ASC"]
-        ));
 
-        return this;
+        return this.completeOrderBy(
+            this._query.orderBy,
+            [orderProperty, "ASC"],
+            options
+        );
     }
 
-    public orderByDescending(propertySelector: (obj: P) => any): IQuery<T, R, P> {
+    public orderByDescending(propertySelector: (obj: P) => any, options?: QueryOrderOptions): IQuery<T, R, P> {
         const propertyName: string = nameof<P>(propertySelector);
         const orderProperty: string = `${this._lastAlias}.${propertyName}`;
-        this._queryParts.push(new QueryBuilderPart(
-            this._query.orderBy,
-            [orderProperty, "DESC"]
-        ));
 
-        return this;
+        return this.completeOrderBy(
+            this._query.orderBy,
+            [orderProperty, "DESC"],
+            options
+        );
     }
 
     public reset(): IQuery<T, R, T> {
@@ -330,26 +331,26 @@ export class Query<T extends EntityBase, R extends T | T[], P = T>
             .then(resolved);
     }
 
-    public thenBy(propertySelector: (obj: P) => any): IQuery<T, R, P> {
+    public thenBy(propertySelector: (obj: P) => any, options?: QueryOrderOptions): IQuery<T, R, P> {
         const propertyName: string = nameof<P>(propertySelector);
         const orderProperty: string = `${this._lastAlias}.${propertyName}`;
-        this._queryParts.push(new QueryBuilderPart(
-            this._query.addOrderBy,
-            [orderProperty, "ASC"]
-        ));
 
-        return this;
+        return this.completeOrderBy(
+            this._query.addOrderBy,
+            [orderProperty, "ASC"],
+            options
+        );
     }
 
-    public thenByDescending(propertySelector: (obj: P) => any): IQuery<T, R, P> {
+    public thenByDescending(propertySelector: (obj: P) => any, options?: QueryOrderOptions): IQuery<T, R, P> {
         const propertyName: string = nameof<P>(propertySelector);
         const orderProperty: string = `${this._lastAlias}.${propertyName}`;
-        this._queryParts.push(new QueryBuilderPart(
-            this._query.addOrderBy,
-            [orderProperty, "DESC"]
-        ));
 
-        return this;
+        return this.completeOrderBy(
+            this._query.addOrderBy,
+            [orderProperty, "DESC"],
+            options
+        );
     }
 
     public thenInclude<S extends Object>(propertySelector: (obj: P) => JoinedEntityType<S>): IQuery<T, R, S> {
@@ -487,6 +488,20 @@ export class Query<T extends EntityBase, R extends T | T[], P = T>
                 queryPart.queryAction.call(builder, ...queryPart.queryParams);
             }
         }
+    }
+
+    private completeOrderBy(queryAction: (...params: any[]) => any, queryParams: any[], options?: QueryOrderOptions): IQuery<T, R, P>{
+        if (options) {
+            if (typeof (options.nullsFirst) === "boolean") {
+                    queryParams.push(options.nullsFirst ? "NULLS FIRST":"NULLS LAST");
+            }
+        }
+        this._queryParts.push(new QueryBuilderPart(
+            queryAction,
+            queryParams
+        ));
+
+        return this;
     }
 
     private completeJoinedWhere(

--- a/src/query/interfaces/IQueryBase.ts
+++ b/src/query/interfaces/IQueryBase.ts
@@ -1,4 +1,5 @@
 import { EntityBase } from "../../types/EntityBase";
+import { QueryOrderOptions } from "../../types/QueryOrderOptions";
 import { JoinedEntityType } from "../../types/JoinedEntityType";
 import { IComparableQuery } from "./IComparableQuery";
 import { IJoinedQuery } from "./IJoinedQuery";
@@ -71,12 +72,12 @@ export interface IQueryBase<T extends EntityBase, R extends T | T[], P = T> {
      * Orders the query on the specified property in ascending order.
      * @param propertySelector Property selection lambda for property on which to sort.
      */
-    orderBy(propertySelector: (obj: P) => any): IQuery<T, R, P>;
+    orderBy(propertySelector: (obj: P) => any, options?: QueryOrderOptions): IQuery<T, R, P>;
     /**
      * Orders the query on the specified property in descending order.
      * @param propertySelector Property selection lambda for property on which to sort.
      */
-    orderByDescending(propertySelector: (obj: P) => any): IQuery<T, R, P>;
+    orderByDescending(propertySelector: (obj: P) => any, options?: QueryOrderOptions): IQuery<T, R, P>;
     /**
      * Returns the query back to its base type while also exiting "join mode",
      * thus ending a join chain so that where conditions may be continued on the base type.
@@ -101,12 +102,12 @@ export interface IQueryBase<T extends EntityBase, R extends T | T[], P = T> {
      * Adds a subsequent ordering to the query on the specified property in ascending order.
      * @param propertySelector Property selection lambda for property on which to sort.
      */
-    thenBy(propertySelector: (obj: P) => any): IQuery<T, R, P>;
+    thenBy(propertySelector: (obj: P) => any, options?: QueryOrderOptions): IQuery<T, R, P>;
     /**
      * Adds a subsequent ordering to the query on the specified property in descending order.
      * @param propertySelector Property selection lambda for property on which to sort.
      */
-    thenByDescending(propertySelector: (obj: P) => any): IQuery<T, R, P>;
+    thenByDescending(propertySelector: (obj: P) => any, options?: QueryOrderOptions): IQuery<T, R, P>;
     /**
      * Includes a subsequent navigation property in the previously included relationship of type P.
      * @type {S} The type of the joined navigation property.

--- a/src/types/QueryOrderOptions.ts
+++ b/src/types/QueryOrderOptions.ts
@@ -1,0 +1,9 @@
+/**
+ * Options for query ordering such as where to put nulls (supported by some databases).
+ */
+export interface QueryOrderOptions {
+    /**
+     * Whether to put null values first when ordering query results.
+     */
+    nullsFirst?: boolean;
+}


### PR DESCRIPTION
TypeOrm allows to specify the ordering of nulls when ordering. 
https://github.com/typeorm/typeorm/commit/2e20a9f5e689e5d44d644474f6a4a5d886ccf3ff

Therefore I added OrderingOptions where you can specify if you want to order null values and in which order.

Please let me know if I should adjust the Readme too.